### PR TITLE
Add Milestone 4 Communicating Results retrospective (group & individual)

### DIFF
--- a/collaboration/retrospectives/4_communicating_results_group_retrospective.md
+++ b/collaboration/retrospectives/4_communicating_results_group_retrospective.md
@@ -1,0 +1,133 @@
+# **Milestone Retrospective: Communicating Results**
+
+This milestone was about **sharing our research findings with the audiences
+who can use them** —
+translating the insights from our recent data analysis into messages, visuals,
+and tools our audiences could connect with and act on.
+
+We worked across formats: a narrative landing page, tailored recommendations,
+visual data stories, and a downloadable report. The focus was on balancing
+**creativity with clarity**, tailoring content for decision-makers while staying
+true to the evidence.
+
+Our work was shaped by constant feedback, iteration, and a shared goal
+of making our findings both **credible and compelling**.
+
+👉 _For individual perspectives — including personal learnings and
+contributions —
+see [Milestone 4: Individual Reflections](./4_communicating_results_individual_reflections.md)._
+
+---
+
+## **Key Achievements**
+
+* **Regained focus after a slow start:** While momentum was low at first, we
+  collectively refocused, agreed on the landing page as our central artifact,
+  and rallied to deliver strong outputs.
+
+* **Purpose-driven alignment:** Once the central artifact was decided, our
+  messaging and design choices became sharper and more audience-focused.
+
+* **Stronger follow-through from past lessons:** We applied planning and role
+  clarity strategies from earlier milestones, leading to more cohesive outputs.
+
+* **Audience-aware recommendations:** Recommendations and outreach concepts
+  were designed with specific priority audiences in mind, keeping them
+  relevant and actionable.
+
+* **Leveraging diverse strengths:** We trusted each other’s expertise, which
+  allowed people to lead in the areas they knew best — from data visuals and
+  narrative writing to design and outreach strategy.
+
+* **Collaborative iteration:** Feedback was respectful and useful, helping
+  us improve quality while still moving the work forward.
+
+---
+
+## **Challenges Faced**
+
+We learned a lot from the difficulties encountered during this milestone.
+Understanding these challenges helps us identify areas for growth.
+
+* **Slow initial momentum:** Energy was lower at the start of the milestone.  
+  _Root Cause:_ Overlap with previous deliverables and presentation prep, plus
+  residual fatigue from the prior milestone, delayed full focus on Milestone 4 work.
+
+* **Maintaining focus amid parallel tasks:** Working on the presentation pulled
+  attention away at points.  
+  _Root Cause:_ Scheduling overlap between milestone and group presentation reduced
+  available deep-work time.
+
+* **Narrowing audience focus:** Relevance to multiple groups made
+  prioritization difficult, as we debated whether to include adjacent advocacy
+  audiences (e.g., journalists, disability rights advocates) alongside our chosen
+  social good organisations.  
+  _Root Cause:_ Balancing reach and specificity required repeated revisiting of
+  the audience scope.
+
+* **Late-stage realizations:** Some refinements to artifacts and deliverables
+  only became clear near the deadline, which left less time for polish.  
+  _Root Cause:_ Final review feedback surfaced gaps only after most production
+  work was complete.
+
+* **Balancing ambition with capacity:** Creative ideas for visuals and
+  formats couldn’t all be executed.  
+  _Root Cause:_ Limited time and technical familiarity restricted experimentation.
+
+---
+
+## **Lessons Learned**
+
+Based on our achievements and challenges, here are the key takeaways and
+insights we gained:
+
+* **Resilience pays off:** Even after a slow start, committing to achievable
+  wins helped the team rebuild momentum and finish strong.
+
+* **Define audience early:** Locking in the “who” and “how” of communication
+  before content creation makes the rest of the process smoother and more
+  impactful.
+
+* **Brainstorm visuals early:** Scheduling early creative sessions on how to
+  present findings can prevent missed opportunities and rushed last-minute
+  design work.
+
+* **Check in beyond tasks:** Regularly asking if teammates feel supported —
+  not just whether tasks are on track — strengthens trust and team morale.
+
+* **Structure supports outreach:** A clear, systematic approach to stakeholder
+  engagement (including message framing and targeting) improves both quality
+  and confidence in delivery.
+
+---
+
+## **Action Plan & Next Steps**
+
+As we transition into the **Final Presentation Event**, we commit to
+applying the lessons learned to improve our processes and outcomes.
+
+* **Start early:** Begin developing the presentation narrative and visuals in
+  week 1 of the milestone to avoid last-minute rush.
+
+* **Anchor in audience needs:** Tailor our 1-minute pitch and 3-minute process
+  presentation to engage peers, and ET team and partners, while keeping the
+  policy relevance clear.
+
+* **Leverage our artifacts:** Integrate highlights from the landing page,
+  recommendations, and visuals into the live presentation for consistency and
+  credibility.
+
+* **Balance prep and assign clear roles:** Coordinate workload for the final
+  presentation and decide early who will handle which parts, slides, and Q&A.
+
+* **Keep momentum with small wins:** Set micro-deadlines for slide completion,
+  run-throughs, and feedback cycles to maintain energy throughout the milestone.
+
+* **Continue collaborative feedback:** Keep using shared documents and
+  comments for centralized, constructive input.
+
+---
+
+>_“Good communication is as much about listening as it is about telling.
+This milestone reminded us that our audience’s needs shape not just the
+message, but how we deliver it — together, with clarity and purpose.”_

--- a/collaboration/retrospectives/4_communicating_results_individual_reflections.md
+++ b/collaboration/retrospectives/4_communicating_results_individual_reflections.md
@@ -1,0 +1,192 @@
+# Individual Retrospectives – Milestone 4: Communicating Results
+
+This document brings together each team member’s personal reflections from the
+Communicating Results milestone.
+These accounts capture what worked well, the specific challenges we faced, and
+the lessons learned along the way.
+
+Each perspective offers a unique take on how we approached sharing our findings
+— from crafting narrative-driven artifacts to designing audience-tailored materials.
+Together, they provide a richer backdrop to our group retrospective, showing
+the range of experiences, skills, and insights gained during this phase.
+
+---
+
+## Jola's Reflection
+
+**What went well?**
+
+- Teamwork and synergy were on point
+
+**What were the challenges?**
+
+- We did not start early enough, perhaps because we were distracted by the
+  presentation. As such, I believe we could have strengthened/refined the
+  artefact if we had more time.
+- We struggled a bit to present a grounded, emotional resonant and trustworthy
+  narrative in our communication.
+
+**What did you learn or discover?**
+
+- When it comes to communicating your findings, you have to think audience first.
+- In our case, an emotionally resonant and grounded approach, which even
+  amplifies grassroots initiative or community networks already doing the work,
+  will connect more to our audience.
+
+**What’s one thing you’ll do differently next time?**
+
+- Start early.
+
+**Any final thoughts on collaboration?**
+
+- Collaboration was great. Each member was responsive and dedicated to their
+  tasks, even delivering more than expected. Beyond that, we also helped each
+  other with respective tasks, and focused on the goal rather than just
+  completing personal assignments.
+
+---
+
+## Karim's Reflection
+
+**What went well?**
+
+- We aligned as a team on a single main communication artifact (the landing
+  page) after exploring different options.
+- The discussion connected the artifact design to specific audiences and
+  findings, making our approach more purposeful.
+
+**What were the challenges?**
+
+- We had difficulty defining the right target audience and especially narrowing
+  it down, since we initially had very different audiences in mind touching
+  different findings.
+
+**What did you learn or discover?**
+
+- Having one clear, narrative-focused artifact can be more impactful than
+  trying to spread efforts across too many formats.
+- Tying communication formats directly to audience needs and constraints makes
+  planning easier and more targeted.
+
+**What’s one thing you’ll do differently next time?**
+
+- Make earlier decisions on audience and artifact format so we can dedicate
+  more time to production and outreach.
+
+**Any final thoughts on collaboration?**
+
+- The mix of perspectives in the team has been really valuable for shaping both
+  personas and artifact ideas.
+- Using shared documents was especially effective — it kept our work
+  organized, made it easier to contribute asynchronously, and was a key factor
+  in keeping the project moving smoothly.
+
+---
+
+## Muqadsa's Reflection
+
+**What went well?**
+
+- Our feedback process was genuinely constructive. We improved the quality of
+  our work through open, thoughtful exchanges—without creating tension or
+  slowing things down.
+
+**What were the challenges?**
+
+- We could have made more space early in the milestone to brainstorm creative
+  ways to visualize our data.
+- Also, defining smaller internal deadlines upfront might have helped us
+  manage time better toward the end.
+
+**What did you learn or discover?**
+
+- I learned that regular check-ins shouldn’t just be about tasks—they’re also
+  a moment to ask if a teammate feels supported.
+- I learned that even with a clear deliverable, taking the time to discuss
+  the underlying definitions and purpose of a task is crucial for team alignment.
+- And I came away with a deep appreciation for how powerful persona-driven
+  communication can be.
+
+**What’s one thing you’ll do differently next time?**
+
+- I’d encourage us to use the “Comments” feature in our shared docs more often.
+  It helps centralize feedback and keeps our chat threads focused.
+
+**Any final thoughts on collaboration?**
+
+- I really appreciated how everyone trusted each other’s strengths, and we
+  created space to explore different approaches without friction.
+
+---
+
+## Omnia's Reflection
+
+**What went well?**
+
+- The team showed resilience and adaptability - after a slow start, we
+  regrouped and delivered strong work when it mattered most.
+- Our final deliverables demonstrated clear improvement from the previous
+  milestone, showing we learned from past experiences and applied those lessons
+  effectively.
+
+**What were the challenges?**
+
+- Initial momentum was slow and the team felt somewhat demotivated at the
+  beginning of this milestone due to previous setbacks.
+- There was less of the collaborative energy and synergy we had experienced in
+  earlier milestones, which affected our initial progress.
+
+**What did you learn or discover?**
+
+- I learned that teams can recover from low points if members are willing to
+  refocus and recommit to the work - resilience is a key team skill.
+- Following Muqadsa's insight, I discovered how important it is to check in on
+  teammates' well-being and support, not just task progress.
+
+**What’s one thing you’ll do differently next time?**
+
+- I will suggest we establish early momentum by setting smaller, achievable
+  wins at the start of each milestone to maintain team morale and energy throughout.
+
+**Any final thoughts on collaboration?**
+
+- While we started slower than usual, I'm proud that the team was able to rally
+  and deliver quality work. It showed our underlying strength as a
+  collaborative unit, even when facing motivation challenges.
+
+---
+
+## Robel's Reflection
+
+**What went well?**
+
+- We had good team work and everybody was working on their task.
+- We understood this milestone earlier as compared to the previous one and
+  made the best out of it.
+
+**What were the challenges?**
+
+- As always, we keep on realizing things around the due dates on how the
+  artifacts and the deliverables are.
+- Balancing limited time against insufficient knowledge was another challenge
+  which complicated our efforts to develop communication artifacts cohesively
+  and avoid diverging from our core objectives.
+
+**What did you learn or discover?**
+
+- I have Learned to structure compelling cold messages for stakeholders engagement
+- I have also learned how to systematically identify stakeholders based on
+  research goals.
+
+**What’s one thing you’ll do differently next time?**
+
+- Try to sharpen our thoughts and get ready for the second and final phase
+  presentation because we have learned from the previous one.
+- Also as always, we will try to finish our meetings on their respective times.
+
+**Any final thoughts on collaboration?**
+
+- Our identity as learners + our work's dual focus + The translation imperative
+  = Artifacts with purpose.
+  
+---

--- a/collaboration/retrospectives/README.md
+++ b/collaboration/retrospectives/README.md
@@ -46,7 +46,8 @@ uncertainty by defining boundaries, and aligning expectations.
 
 ### **Milestone 4: Communicating Results**
 
-👥 [`4_communicating_results.md`](./4_communicating_results.md) – Lessons from designing communication artifacts and identifying the right audiences.
+👥 [`4_communicating_results_group_retrospective.md`](./4_communicating_results_group_retrospective.md) – Group reflections on designing communication artifacts and identifying the right audiences.  
+🧍 [`4_communicating_results_individual_reflections.md`](./4_communicating_results_individual_reflections.md) – Personal insights on creating narrative artifacts, adapting to an audience-first approach, and managing parallel tasks.
 
 ### **Milestone 5: Final Presentation**
 


### PR DESCRIPTION
**PR Description:**

This PR replaces the old combined Milestone 4 retrospective with two separate Markdown files:

* `4_communicating_results_group_retrospective.md` (final group reflection)
* `4_communicating_results_individual_reflections.md` (collected individual reflections)

It also updates the `collaboration/retrospectives/README.md` to link to these new files.
The change improves clarity, maintains milestone documentation standards, and aligns with the repo’s structure for previous retrospectives.

**Linked Issue:**
Closes #232  (Team retrospective tracking issue)

---

**General Checks** 

* [x] branch is up to date with `main`
* [x] PR has a descriptive title
* [x] All CI checks pass (or at least discussed).
* [x] All conflicts are resolved (if any).
* [x] PR has appropriate labels: `documentation`, `retrospective`
* [x] PR is assigned to owner and reviewers assigned
* [x] PR contains only one focused change (Milestone 4 retrospective replacement)
* [x] linked to relevant issue

**Markdown Checks** 

* [x] The retrospective content is a clear and fair summary of team input.
* [x] Key achievements, challenges, lessons learned, and action items are clearly articulated.
* [x] Markdown formatted and previewed
* [x] Spelling/grammar checked
* [x] Links work (README links to new files correctly)
